### PR TITLE
Feature/#12 implement sidebar and app menu based on figma design

### DIFF
--- a/src/common/appbar/appbar.component.tsx
+++ b/src/common/appbar/appbar.component.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Link } from '@tanstack/react-router';
+
+import { AppBar as MUIAppbar, IconButton, Toolbar, Typography, Button } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import MenuOpenIcon from '@mui/icons-material/MenuOpen';
+
+import * as classes from './appbar.styles';
+import { AppBarProfile } from './appbar.profile.component';
+
+interface AppBarProps {
+  open?: boolean;
+  isUserlogged?: boolean;
+  handleMenu: () => void;
+}
+
+export const AppBar: React.FC<AppBarProps> = props => {
+  // TODO: Mock User login state until we have concrete data to build it correctly
+  const { isUserlogged = true } = props;
+
+  return (
+    <MUIAppbar
+      className={classes.appBarContainer}
+      position="static"
+      elevation={1}
+      color="default"
+      variant="outlined"
+      square
+    >
+      <Toolbar disableGutters className={classes.toolbar} variant="regular">
+        <div className={classes.leftGroup}>
+          <IconButton color="inherit" onClick={props.handleMenu} aria-label="open drawer">
+            {props.open ? <MenuOpenIcon /> : <MenuIcon />}
+          </IconButton>
+          <Typography variant="h6" fontWeight={'bold'}>
+            GEX
+          </Typography>
+        </div>
+
+        {isUserlogged ? (
+          <AppBarProfile username="PM" />
+        ) : (
+          <Link to="/login">
+            <Button color="primary" variant="outlined">
+              Login
+            </Button>
+          </Link>
+        )}
+      </Toolbar>
+    </MUIAppbar>
+  );
+};

--- a/src/common/appbar/appbar.profile.component.tsx
+++ b/src/common/appbar/appbar.profile.component.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { IconButton, Menu, MenuItem, Tooltip, Typography, Avatar as MuiAvatar } from '@mui/material';
+
+import * as classes from './appbar.profile.styles';
+
+// TODO: Provisional implementation
+const loginSettings = ['Perfil', 'Dashboard', 'Salir'];
+interface Props {
+  username: string;
+  role?: string;
+}
+
+export const AppBarProfile: React.FC<Props> = (props: Props) => {
+  const { username } = props;
+  const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(null);
+  const handleOpenUserMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorElUser(event.currentTarget);
+  };
+
+  const handleCloseUserMenu = () => {
+    setAnchorElUser(null);
+  };
+
+  return (
+    <div className={classes.appBarContainer}>
+      <Tooltip title="Configuración del usuario" placement="left-end">
+        <IconButton onClick={handleOpenUserMenu} className={classes.iconButton}>
+          <MuiAvatar>{username}</MuiAvatar>
+        </IconButton>
+      </Tooltip>
+      <Menu
+        className={classes.menu}
+        id="menu-appbar"
+        anchorEl={anchorElUser}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        keepMounted
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        open={Boolean(anchorElUser)}
+        onClose={handleCloseUserMenu}
+      >
+        {loginSettings.map(setting => (
+          <MenuItem key={setting} onClick={handleCloseUserMenu}>
+            <Typography className={classes.menu__text}>{setting}</Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </div>
+  );
+};

--- a/src/common/appbar/appbar.profile.styles.ts
+++ b/src/common/appbar/appbar.profile.styles.ts
@@ -1,0 +1,16 @@
+import { css } from '@emotion/css';
+
+export const appBarContainer = css`
+  flex-grow: 0;
+`;
+
+export const menu = css`
+  margin-top: 45px;
+`;
+
+export const menu__text = css`
+  text-align: center;
+`;
+export const iconButton = css`
+  padding: 0;
+`;

--- a/src/common/appbar/appbar.styles.ts
+++ b/src/common/appbar/appbar.styles.ts
@@ -1,0 +1,23 @@
+import { css } from '@emotion/css';
+
+export const toolbar = css`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-content: center;
+  align-items: center;
+  padding: 0 48px 0 12px;
+`;
+
+export const appBarContainer = css`
+  z-index: 2;
+`;
+
+export const leftGroup = css`
+  flex-grow: 1;
+  display: flex;
+  justify-content: start;
+  align-content: center;
+  align-items: center;
+  gap: 30px;
+`;

--- a/src/common/appbar/index.ts
+++ b/src/common/appbar/index.ts
@@ -1,0 +1,1 @@
+export * from './appbar.component';

--- a/src/common/drawer/drawer.component.tsx
+++ b/src/common/drawer/drawer.component.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import MuiDrawer from '@mui/material/Drawer';
+import { useTheme } from '@mui/material';
+
+import * as classes from './drawer.styles';
+
+interface Props {
+  open?: boolean;
+  drawerWidth?: number;
+  children: React.ReactNode;
+}
+
+export const Drawer: React.FC<Props> = (props: Props) => {
+  const { open = false, drawerWidth = 240, children } = props;
+  const theme = useTheme();
+  return (
+    <MuiDrawer variant="permanent" className={classes.responsiveAnimatedDrawer(open, theme, drawerWidth)} open={open}>
+      {children}
+    </MuiDrawer>
+  );
+};

--- a/src/common/drawer/drawer.styles.tsx
+++ b/src/common/drawer/drawer.styles.tsx
@@ -1,0 +1,30 @@
+import { Theme } from '@mui/material/styles';
+import { css } from '@emotion/css';
+
+export const responsiveAnimatedDrawer = (isOpen: boolean, theme: Theme, drawerWidth: number): string => css`
+  flex-shrink: 0;
+  white-space: nowrap;
+  box-sizing: border-box;
+  z-index: 1;
+  background-color: ${theme.palette.background.paper};
+  /** WARN: regarding MUI API classNames.
+    * Unlike 'styled()' approach shown in MUI web examples,
+    * the 'Emotion template string' classes MUST match their case-sensitive names.
+  */
+  /** NOTE: When using an animated drawer,
+    * some styles must be duplicated also in its 'paper component' child to work*/
+  &,
+  & .MuiDrawer-paper {
+    position: relative;
+    width: ${isOpen ? drawerWidth + 'px' : theme.spacing(9)};
+    overflow-x: hidden;
+    transition: ${theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: isOpen ? theme.transitions.duration.enteringScreen : theme.transitions.duration.leavingScreen,
+    })};
+    @media screen and (max-width: ${theme.breakpoints.values.lg}px) {
+      position: absolute;
+      height: 100%;
+    }
+  }
+`;

--- a/src/common/drawer/index.ts
+++ b/src/common/drawer/index.ts
@@ -1,0 +1,1 @@
+export * from './drawer.component';

--- a/src/common/sidebar-menu/index.ts
+++ b/src/common/sidebar-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './sidebar-menu.component';

--- a/src/common/sidebar-menu/item.sidebar-menu.component.tsx
+++ b/src/common/sidebar-menu/item.sidebar-menu.component.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+
+// TODO: implement router links
+interface Props {
+  text: string;
+  IconComponent?: React.ComponentType;
+  isSelected: boolean;
+}
+
+export const Item: React.FC<Props> = (props: Props) => {
+  const { text, IconComponent, isSelected } = props;
+  return (
+    <ListItem key={text}>
+      <ListItemButton selected={isSelected}>
+        {IconComponent && <ListItemIcon>{<IconComponent />}</ListItemIcon>}
+        <ListItemText primary={text} />
+      </ListItemButton>
+    </ListItem>
+  );
+};

--- a/src/common/sidebar-menu/item.sidebar-menu.component.tsx
+++ b/src/common/sidebar-menu/item.sidebar-menu.component.tsx
@@ -1,25 +1,71 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { Link as RouterLink } from '@tanstack/react-router';
 
+import MuiLink from '@mui/material/Link';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 
-// TODO: implement router links
-interface Props {
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { Collapse, List, useTheme } from '@mui/material';
+
+import * as classes from './item.sidebar-menu.styles';
+
+interface ItemProps {
   text: string;
   IconComponent?: React.ComponentType;
-  isSelected: boolean;
+  // TODO: implement router links with safe types
+  linkPath: string;
 }
 
-export const Item: React.FC<Props> = (props: Props) => {
-  const { text, IconComponent, isSelected } = props;
+export const Item: React.FC<ItemProps> = (props: ItemProps) => {
+  const { text, IconComponent, linkPath } = props;
+
+  return (
+    <MuiLink component={RouterLink} to={linkPath} underline="none" color="textPrimary">
+      <ListItem key={text}>
+        {/* TODO: implement 'active path matching' using the router hook. "/users" path is used below just as an example */}
+        <ListItemButton selected={linkPath === '/users'}>
+          {IconComponent && <ListItemIcon>{<IconComponent />}</ListItemIcon>}
+          <ListItemText primary={text} />
+        </ListItemButton>
+      </ListItem>
+    </MuiLink>
+  );
+};
+
+interface ExpandableItemProps extends ItemProps {
+  isDrawerOpened: boolean;
+  children: React.ReactNode;
+}
+
+export const ExpandableItem: React.FC<ExpandableItemProps> = (props: ExpandableItemProps) => {
+  const { text, IconComponent, isDrawerOpened, children } = props;
+  const [isListExpanded, setIsListExpanded] = React.useState(false);
+  const theme = useTheme();
+  const handleClick = () => {
+    setIsListExpanded(!isListExpanded);
+  };
+
+  useEffect(() => {
+    if (!isDrawerOpened) {
+      setIsListExpanded(false);
+    }
+  }, [isDrawerOpened]);
+
   return (
     <ListItem key={text}>
-      <ListItemButton selected={isSelected}>
+      <ListItemButton onClick={handleClick}>
         {IconComponent && <ListItemIcon>{<IconComponent />}</ListItemIcon>}
         <ListItemText primary={text} />
+        {isDrawerOpened ? isListExpanded ? <ExpandLess /> : <ExpandMore /> : ''}
       </ListItemButton>
+      <Collapse in={isListExpanded} timeout="auto" unmountOnExit>
+        <List component="div" className={classes.itemsExtraIndent(theme)} disablePadding>
+          {children}
+        </List>
+      </Collapse>
     </ListItem>
   );
 };

--- a/src/common/sidebar-menu/item.sidebar-menu.styles.ts
+++ b/src/common/sidebar-menu/item.sidebar-menu.styles.ts
@@ -1,0 +1,8 @@
+import { css } from '@emotion/css';
+import { Theme } from '@mui/material';
+
+export const itemsExtraIndent = (theme: Theme) => css`
+  & .MuiListItem-root {
+    margin-left: ${theme.spacing(5)};
+  }
+`;

--- a/src/common/sidebar-menu/sidebar-menu.component.tsx
+++ b/src/common/sidebar-menu/sidebar-menu.component.tsx
@@ -1,0 +1,43 @@
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import InboxIcon from '@mui/icons-material/MoveToInbox';
+import List from '@mui/material/List';
+import { Divider, useTheme } from '@mui/material';
+import * as classes from './sidebar-menu.styles';
+
+interface Props {
+  open: boolean;
+}
+
+// TODO: Provisional. Pending to implement with dropdown menus and proper Icons
+export const SidebarMenu = (props: Props) => {
+  const { open = false } = props;
+  const theme = useTheme();
+  return (
+    <List className={classes.list(theme, open)}>
+      {['Principal', 'Expedientes', 'Empresas', 'Informes'].map(text => (
+        <ListItem key={text}>
+          <ListItemButton>
+            <ListItemIcon>
+              <InboxIcon />
+            </ListItemIcon>
+            <ListItemText primary={text} />
+          </ListItemButton>
+        </ListItem>
+      ))}
+
+      <Divider variant="middle" />
+
+      <ListItem key={'Usuarios'}>
+        <ListItemButton selected>
+          <ListItemIcon>
+            <InboxIcon />
+          </ListItemIcon>
+          <ListItemText primary={'Usuarios'} />
+        </ListItemButton>
+      </ListItem>
+    </List>
+  );
+};

--- a/src/common/sidebar-menu/sidebar-menu.component.tsx
+++ b/src/common/sidebar-menu/sidebar-menu.component.tsx
@@ -1,10 +1,16 @@
-import ListItem from '@mui/material/ListItem';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import InboxIcon from '@mui/icons-material/MoveToInbox';
+import React from 'react';
+
 import List from '@mui/material/List';
 import { Divider, useTheme } from '@mui/material';
+
+import HomeIcon from '@mui/icons-material/Home';
+import FolderIcon from '@mui/icons-material/Folder';
+import ApartmentIcon from '@mui/icons-material/Apartment';
+import LeaderboardIcon from '@mui/icons-material/Leaderboard';
+import PersonIcon from '@mui/icons-material/Person';
+
+import { Item } from './item.sidebar-menu.component';
+
 import * as classes from './sidebar-menu.styles';
 
 interface Props {
@@ -12,32 +18,19 @@ interface Props {
 }
 
 // TODO: Provisional. Pending to implement with dropdown menus and proper Icons
-export const SidebarMenu = (props: Props) => {
+export const SidebarMenu: React.FC<Props> = (props: Props) => {
   const { open = false } = props;
   const theme = useTheme();
   return (
     <List className={classes.list(theme, open)}>
-      {['Principal', 'Expedientes', 'Empresas', 'Informes'].map(text => (
-        <ListItem key={text}>
-          <ListItemButton>
-            <ListItemIcon>
-              <InboxIcon />
-            </ListItemIcon>
-            <ListItemText primary={text} />
-          </ListItemButton>
-        </ListItem>
-      ))}
+      <Item text="Principal" IconComponent={HomeIcon} isSelected={false} />
+      <Item text="Expedientes" IconComponent={FolderIcon} isSelected={false} />
+      <Item text="Empresas" IconComponent={ApartmentIcon} isSelected={false} />
+      <Item text="Informes" IconComponent={LeaderboardIcon} isSelected={false} />
 
       <Divider variant="middle" />
 
-      <ListItem key={'Usuarios'}>
-        <ListItemButton selected>
-          <ListItemIcon>
-            <InboxIcon />
-          </ListItemIcon>
-          <ListItemText primary={'Usuarios'} />
-        </ListItemButton>
-      </ListItem>
+      <Item text="Usuarios" IconComponent={PersonIcon} isSelected={true} />
     </List>
   );
 };

--- a/src/common/sidebar-menu/sidebar-menu.component.tsx
+++ b/src/common/sidebar-menu/sidebar-menu.component.tsx
@@ -9,7 +9,7 @@ import ApartmentIcon from '@mui/icons-material/Apartment';
 import LeaderboardIcon from '@mui/icons-material/Leaderboard';
 import PersonIcon from '@mui/icons-material/Person';
 
-import { Item } from './item.sidebar-menu.component';
+import { Item, ExpandableItem } from './item.sidebar-menu.component';
 
 import * as classes from './sidebar-menu.styles';
 
@@ -17,20 +17,25 @@ interface Props {
   open: boolean;
 }
 
-// TODO: Provisional. Pending to implement with dropdown menus and proper Icons
+// TODO: Provisional. Pending to implement routing links
 export const SidebarMenu: React.FC<Props> = (props: Props) => {
   const { open = false } = props;
   const theme = useTheme();
   return (
     <List className={classes.list(theme, open)}>
-      <Item text="Principal" IconComponent={HomeIcon} isSelected={false} />
-      <Item text="Expedientes" IconComponent={FolderIcon} isSelected={false} />
-      <Item text="Empresas" IconComponent={ApartmentIcon} isSelected={false} />
-      <Item text="Informes" IconComponent={LeaderboardIcon} isSelected={false} />
+      <Item text="Principal" IconComponent={HomeIcon} linkPath={'/'} />
+      <ExpandableItem text="Expedientes" IconComponent={FolderIcon} linkPath={'/'} isDrawerOpened={open}>
+        <Item text="Listado" linkPath={'/'} />
+        <Item text="Nuevo ACF" linkPath={'/'} />
+        <Item text="..." linkPath={'/'} />
+      </ExpandableItem>
+
+      <Item text="Empresas" IconComponent={ApartmentIcon} linkPath={'/'} />
+      <Item text="Informes" IconComponent={LeaderboardIcon} linkPath={'/'} />
 
       <Divider variant="middle" />
 
-      <Item text="Usuarios" IconComponent={PersonIcon} isSelected={true} />
+      <Item text="Usuarios" IconComponent={PersonIcon} linkPath={'/users'} />
     </List>
   );
 };

--- a/src/common/sidebar-menu/sidebar-menu.styles.ts
+++ b/src/common/sidebar-menu/sidebar-menu.styles.ts
@@ -1,0 +1,33 @@
+import { css } from '@emotion/css';
+import { Theme } from '@mui/material';
+
+export const list = (theme: Theme, open: boolean) => css`
+  & .MuiListItem-root {
+    display: block;
+    padding: ${theme.spacing(1)};
+  }
+
+  & .MuiListItemButton-root {
+    min-height: 48px;
+    justify-content: ${open ? 'initial' : 'center'};
+  }
+  & .MuiListItemText-root {
+    opacity: ${open ? 1 : 0};
+  }
+
+  & .MuiListItemIcon-root {
+    min-width: 0;
+    justify-content: center;
+    margin-right: ${open ? theme.spacing(3) : 'auto'};
+  }
+
+  & .Mui-selected {
+    color: ${theme.palette.primary.main};
+    background-color: ${theme.palette.tonalOffset};
+    border-radius: 4px;
+
+    & .MuiListItemIcon-root {
+      color: ${theme.palette.primary.main};
+    }
+  }
+`;

--- a/src/layouts/app.layout.tsx
+++ b/src/layouts/app.layout.tsx
@@ -1,29 +1,33 @@
 import React from 'react';
-import { AppBar, IconButton, Toolbar, Typography } from '@mui/material';
-import { Link } from '@tanstack/react-router';
-import LogoutIcon from '@mui/icons-material/Logout';
+import { useTheme } from '@mui/material';
+
+import { AppBar } from '#common/appbar/';
+import { Drawer } from '#common/drawer/';
+import { SidebarMenu } from '#common/sidebar-menu/index.ts';
+
 import * as classes from './app.styles';
 
 interface Props {
   children: React.ReactNode;
 }
 
+// TODO: handle this 'isUserlogged' properly when auth is implemented
+const isUserlogged: boolean = true;
+
 export const AppLayout: React.FC<Props> = props => {
   const { children } = props;
-
+  const [open, setOpen] = React.useState(false);
+  const toggleDrawer = () => setOpen(open => !open);
+  const theme = useTheme();
   return (
-    <>
-      <AppBar position="static">
-        <Toolbar className={classes.toolbar}>
-          <Typography variant="h6">AppBar</Typography>
-          <IconButton size="large" edge="start" sx={{ mr: 2 }}>
-            <Link to="/login" style={{ color: 'white' }}>
-              <LogoutIcon />
-            </Link>
-          </IconButton>
-        </Toolbar>
-      </AppBar>
-      <main className={classes.content}>{children}</main>
-    </>
+    <div className={classes.appContainer}>
+      <AppBar open={open} handleMenu={toggleDrawer} isUserlogged={isUserlogged} />
+      <main className={classes.main}>
+        <Drawer open={open} drawerWidth={256}>
+          <SidebarMenu open={open} />
+        </Drawer>
+        <div className={classes.sceneContent(theme)}>{children}</div>
+      </main>
+    </div>
   );
 };

--- a/src/layouts/app.styles.ts
+++ b/src/layouts/app.styles.ts
@@ -12,7 +12,7 @@ export const appContainer = css`
 export const main = css`
   display: flex;
   width: 100%;
-  height: calc(100dvh - 64px);
+  height: calc(100dvh - 68px);
   position: relative;
 `;
 

--- a/src/layouts/app.styles.ts
+++ b/src/layouts/app.styles.ts
@@ -1,16 +1,33 @@
 import { css } from '@emotion/css';
+import { Theme } from '@mui/material';
 
-export const toolbar = css`
+export const appContainer = css`
+  max-width: 100dvw;
+  height: 100dvh;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: start;
 `;
 
-export const content = css`
-  width: 100vw;
-  height: 100vh;
-
+export const main = css`
   display: flex;
-  justify-content: center;
-  align-items: center;
+  width: 100%;
+  height: calc(100dvh - 64px);
+  position: relative;
+`;
+
+export const sceneContent = (theme: Theme) => css`
+  display: flex;
+  justify-content: start;
+  flex-wrap: wrap;
+  overflow: auto;
+  flex-grow: 1;
+  padding: 5dvh ${theme.spacing(9)};
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+  margin-left: 0;
+  @media screen and (max-width: ${theme.breakpoints.values.lg}px) {
+    margin-left: ${theme.spacing(9)}; //Equals the width of <Drawer/> minified version;
+  }
 `;


### PR DESCRIPTION
**This PR implements an appBar and a sidebar (which is enclosed within a Material UI drawer).**

Notes: 
- To make the drawer effect responsive, the css 'position' of the drawer changes from relative to absolute on smaller screens causing an overlay effect instead of pushing the scene content.
To deal with these two conditions (overlay or push content), the scrolling feature in the app is managed only by the div using the 'sceneContent' css class, keeping the appbar and the drawer 'looked' in their original position.

- Regarding app styles, we use '@emotion/css' library instead of 'mui/material'. 
 **_This approach has one tricky point_** compared to the examples provided in the MUI documentation:
 The MUI examples use the styled() method built into MUI, and it seems to automatically convert the cases of the
MUI API CSS classes automatically.
  **- If you get the examples directly from the DOC and want to convert them to @emotion/css template stringd, make sure that you change these classNames to its correct case style in order to make them work.**
 
 Further steps (added in several // TODOs):
- Implement Router hook to check path matching in the sidebar links
- Implement and improve the appbar user-menu with proper auth states.

closes #12 